### PR TITLE
Update llvm (tests broken)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ ENV PATH "/root/.cargo/bin:${PATH}"
 RUN apt-get update && \
     apt-get dist-upgrade -y && \
     apt-get install -y \
-        apt-transport-https build-essential clang-5.0 cmake curl git \
-        libjsoncpp-dev libyaml-cpp-dev lld-5.0 pkg-config python3 python3-pip \
+        apt-transport-https build-essential clang-7 cmake curl git \
+        libjsoncpp-dev libyaml-cpp-dev lld-7 pkg-config python3 python3-pip \
         wget && \
     pip3 install pypeg2 toposort && \
     \
@@ -14,12 +14,12 @@ RUN apt-get update && \
                   armv7-unknown-cloudabi-eabihf i686-unknown-cloudabi \
                   x86_64-unknown-cloudabi; do \
       for tool in ar nm objdump ranlib size; do \
-        ln -s ../lib/llvm-5.0/bin/llvm-${tool} /usr/bin/${target}-${tool}; \
+        ln -s ../lib/llvm-7/bin/llvm-${tool} /usr/bin/${target}-${tool}; \
       done && \
-      ln -s ../lib/llvm-5.0/bin/clang /usr/bin/${target}-cc && \
-      ln -s ../lib/llvm-5.0/bin/clang /usr/bin/${target}-c++ && \
-      ln -s ../lib/llvm-5.0/bin/lld /usr/bin/${target}-ld && \
-      ln -s ../../${target} /usr/lib/llvm-5.0/${target}; \
+      ln -s ../lib/llvm-7/bin/clang /usr/bin/${target}-cc && \
+      ln -s ../lib/llvm-7/bin/clang /usr/bin/${target}-c++ && \
+      ln -s ../lib/llvm-7/bin/lld /usr/bin/${target}-ld && \
+      ln -s ../../${target} /usr/lib/llvm-7/${target}; \
     done && \
     \
     echo deb https://nuxi.nl/distfiles/cloudabi-ports/debian/ cloudabi cloudabi > /etc/apt/sources.list.d/cloudabi.list && \


### PR DESCRIPTION
I was unable to get the current Dockerfile to buld. clang-5.0 is no longer available in `debian:testing`.

This dockerfile builds successfully, but it fails the testsuite non-deterministically. Any thoughts on why the tests might be failing?

As an example: 
```
root@88e39bb79e41:/# cloudabi-run -e /usr/x86_64-unknown-cloudabi/bin/cloudlibc-unittests << EOF
%TAG ! tag:nuxi.nl,2015:cloudabi/
---
tmpdir: !file
  path: tmp-unittest
logfile: !fd stdout
EOF
WARNING: Attempting to start executable using emulation.
Keep in mind that this emulation provides no actual sandboxing.
Though this is likely no problem for development and testing
purposes, using this emulator in production is strongly
discouraged.
-> drand48::bounds
-> fdopen::bad
-> localtime_l::santiago
-> fflush::eagain
-> wcsrtombs::ascii_null_ok
-> wmemset::example
-> call_once::example
-> clock_nanosleep::monotonic_relative
-> fread::zero
-> unlinkat::examples
-> uv_ip4_addr::einval
-> wctomb::euro
-> scandirat::even_files
Test failed
--
Statement: ASSERT_EQ(0, mkdirat(state->tmpdir, test->__name))
Expected:           0 ==          0 == (0)
Actual:            -1 == 0xffffffff == (mkdirat(state->tmpdir, test->__name))
Location:  src/libc/testing/testing_execute.c:82
Errno:     20, File exists
Aborted (core dumped)
```